### PR TITLE
Complete removal of Go regexp

### DIFF
--- a/builtin.go
+++ b/builtin.go
@@ -217,8 +217,7 @@ func _builtinGlobal_encodeURI(call FunctionCall, escape *p5r.Regexp) Value {
 		output = append(output, encode...)
 	}
 	{
-		regexp_escape := escape.MustConvert()
-		value := regexp_escape.ReplaceAllFunc(output, func(target []byte) []byte {
+		value := escape.ReplaceAllFunc(output, func(target []byte) []byte {
 			// TODO There is probably a better way of doing this
 			if target[0] == ' ' {
 				return []byte("%20")

--- a/builtin_string.go
+++ b/builtin_string.go
@@ -137,8 +137,7 @@ func builtinString_match(call FunctionCall) Value {
 	}
 
 	{
-		// TODO: Use p5r directly instead of converting to a regexp struct
-		regexp_matcher := matcher.regExpValue().regularExpression.MustConvert()
+		regexp_matcher := matcher.regExpValue().regularExpression
 		result := regexp_matcher.FindAllStringIndex(target, -1)
 		matchCount := len(result)
 		if result == nil {
@@ -163,8 +162,7 @@ func builtinString_findAndReplaceString(input []byte, lastIndex int, match []int
 	if match[0] != lastIndex {
 		output = append(output, target[lastIndex:match[0]]...)
 	}
-	// TODO: Use p5r directly instead of converting to a regexp struct
-	replacement := builtinString_replace_Regexp.MustConvert().ReplaceAllFunc(replaceValue, func(part []byte) []byte {
+	replacement := builtinString_replace_Regexp.ReplaceAllFunc(replaceValue, func(part []byte) []byte {
 		// TODO Check if match[0] or match[1] can be -1 in this scenario
 		switch part[1] {
 		case '$':
@@ -211,8 +209,7 @@ func builtinString_replace(call FunctionCall) Value {
 		search = p5r.MustCompile(p5r.QuoteMeta(searchValue.string()))
 	}
 
-	// TODO: Use p5r directly instead of converting to a regexp struct
-	found := search.MustConvert().FindAllSubmatchIndex(target, find)
+	found := search.FindAllSubmatchIndex(target, find)
 	if found == nil {
 		return toValue_string(string(target)) // !match
 	}
@@ -274,8 +271,7 @@ func builtinString_search(call FunctionCall) Value {
 	if !searchValue.IsObject() || search.class != "RegExp" {
 		search = call.runtime.newRegExp(searchValue, Value{})
 	}
-	// TODO: Use p5r directly instead of converting to a regexp struct
-	result := search.regExpValue().regularExpression.MustConvert().FindStringIndex(target)
+	result := search.regExpValue().regularExpression.FindStringIndex(target)
 	if result == nil {
 		return toValue_int(-1)
 	}
@@ -316,8 +312,7 @@ func builtinString_split(call FunctionCall) Value {
 		targetLength := len(target)
 		search := separatorValue._object().regExpValue().regularExpression
 		valueArray := []Value{}
-		// TODO: Use p5r directly instead of converting to a regexp struct
-		result := search.MustConvert().FindAllStringSubmatchIndex(target, -1)
+		result := search.FindAllStringSubmatchIndex(target, -1)
 		lastIndex := 0
 		found := 0
 

--- a/dbg/dbg.go
+++ b/dbg/dbg.go
@@ -62,7 +62,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"regexp"
+	regexp "github.com/xyproto/p5r"
 	"runtime"
 	"strings"
 	"unicode"

--- a/parser/expression.go
+++ b/parser/expression.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"regexp"
+	regexp "github.com/xyproto/p5r"
 
 	"github.com/robertkrimen/otto/ast"
 	"github.com/robertkrimen/otto/file"

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"regexp"
+	regexp "github.com/xyproto/p5r"
 	"strconv"
 	"strings"
 	"unicode"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"errors"
-	"regexp"
+	regexp "github.com/xyproto/p5r"
 	"strings"
 	"testing"
 

--- a/parser/regexp_test.go
+++ b/parser/regexp_test.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"regexp"
+	regexp "github.com/xyproto/p5r"
 	"testing"
 )
 

--- a/repl/autocompleter.go
+++ b/repl/autocompleter.go
@@ -1,7 +1,7 @@
 package repl
 
 import (
-	"regexp"
+	regexp "github.com/xyproto/p5r"
 	"strings"
 
 	"github.com/robertkrimen/otto"

--- a/terst/terst.go
+++ b/terst/terst.go
@@ -35,7 +35,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
-	"regexp"
+	regexp "github.com/xyproto/p5r"
 	"runtime"
 	"strings"
 	"sync"

--- a/test/tester.go
+++ b/test/tester.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"regexp"
+	regexp "github.com/xyproto/p5r"
 	"strings"
 	"sync"
 	"text/tabwriter"

--- a/type_date.go
+++ b/type_date.go
@@ -3,7 +3,7 @@ package otto
 import (
 	"fmt"
 	"math"
-	"regexp"
+	regexp "github.com/xyproto/p5r"
 	Time "time"
 )
 

--- a/type_regexp.go
+++ b/type_regexp.go
@@ -95,7 +95,7 @@ func execRegExp(this *_object, target string) (match bool, result []int) {
 		index = 0
 	}
 	if 0 <= index && index <= int64(len(target)) {
-		result = this.regExpValue().regularExpression.MustConvert().FindStringSubmatchIndex(target[index:])
+		result = this.regExpValue().regularExpression.FindStringSubmatchIndex(target[index:])
 	}
 	if result == nil {
 		//this.defineProperty("lastIndex", toValue_(0), 0111, true)


### PR DESCRIPTION
This PR https://github.com/xyproto/p5r/pull/1 allows complete removal of Go regexp from otto library.