### PR TITLE
Ability to save null values in maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /otto/otto-*
 /test/test-*.js
 /test/tester
+.idea/

--- a/value.go
+++ b/value.go
@@ -720,12 +720,9 @@ func (self Value) export() interface{} {
 			return val.Interface()
 		} else {
 			result := make(map[string]interface{})
-			// TODO Should we export everything? Or just what is enumerable?
 			object.enumerate(false, func(name string) bool {
 				value := object.get(name)
-				if value.IsDefined() {
-					result[name] = value.export()
-				}
+				result[name] = value.export()
 				return true
 			})
 			return result

--- a/value_test.go
+++ b/value_test.go
@@ -221,11 +221,11 @@ func TestExport(t *testing.T) {
 		is(test(`"Nothing happens";`).export(), "Nothing happens")
 		is(test(`String.fromCharCode(97,98,99,100,101,102)`).export(), "abcdef")
 		{
-			value := test(`({ abc: 1, def: true, ghi: undefined });`).export().(map[string]interface{})
+			value := test(`({ abc: 1, def: true, ghi: undefined, jkl: null });`).export().(map[string]interface{})
 			is(value["abc"], 1)
 			is(value["def"], true)
-			_, exists := value["ghi"]
-			is(exists, false)
+			is(value["ghi"], nil)
+			is(value["jkl"], nil)
 		}
 		{
 			value := test(`[ "abc", 1, "def", true, undefined, null ];`).export().([]interface{})


### PR DESCRIPTION
With current version, setting field of JS object to null, resulted in no information about it.

`
var obj = {};
obj.field = null;
`
When otto exports 'obj', it results with empty map.
With proposed change, 'obj' will result in map containing `field` set to `nil`